### PR TITLE
Make collision rect-only

### DIFF
--- a/src/collectable.lua
+++ b/src/collectable.lua
@@ -1,7 +1,10 @@
 
 local sprites = basic.pack 'database.sprites'
+local entity = require 'entity'
 
-local collectable = require 'entity' :new {
+local collectable = entity:new {
+  [3] = 1/2,
+  [4] = 1/4,
   item = 'drumstick',
   __type = 'collectable'
 }
@@ -21,5 +24,10 @@ function collectable:on_death ()
   audio:playSFX('Get')
   hump.signal.emit('entity_death', self)
 end
+
+function collectable:draw ()
+  entity.draw(self) -- call entity draw
+end
+
 
 return collectable

--- a/src/controller/dungeon/player.lua
+++ b/src/controller/dungeon/player.lua
@@ -3,10 +3,10 @@ local dungeon_player = require 'controller' :new {}
 
 local sprites = basic.pack 'database.sprites'
 
-local slash_entity = require 'attack' :new { 0, 0, 1/3 }
+local slash_entity = require 'attack' :new { 0, 0, 1/2, 1/2 }
 local slash_sprite = require 'sprite' :new { sprites.slash }
 
-local player_speed = globals.frameunit * 2/4
+local player_speed = globals.frameunit * 3/4
 
 local function getplayer()
   return hump.gamestate.current():getentity('player')

--- a/src/controller/dungeon/rooms.lua
+++ b/src/controller/dungeon/rooms.lua
@@ -39,7 +39,6 @@ local room_elements = {
       require 'monster' :new {
         2 * globals.width  / 4,
         3 * globals.height / 4,
-        1/4,
         species = 'slime'
       },
       require 'sprite' :new { sprites.slime }
@@ -51,7 +50,6 @@ local room_elements = {
         item = 'drumstick',
         globals.width  / 2,
         globals.height / 2,
-        1/5
       },
       require 'sprite' :new { sprites.drumstick }
     },

--- a/src/database/monsters/slime.lua
+++ b/src/database/monsters/slime.lua
@@ -1,6 +1,6 @@
 
 local slime = {
-  size = 1/5,
+  size = basic.vector:new{ 1/2, 1/4 },
   maxhp  = 3,
   attack = 1,
 }

--- a/src/database/sprites/money.lua
+++ b/src/database/sprites/money.lua
@@ -12,7 +12,7 @@ money[5]  = 0
 money[6]  = 1 / globals.unit
 money[7]  = 1 / globals.unit
 money[8]  = 16
-money[9]  = 16
+money[9]  = 20
 
 money.animations = {
   default = {

--- a/src/entity.lua
+++ b/src/entity.lua
@@ -45,6 +45,10 @@ function entity:update ()
 end
 
 function entity:draw ()
+  love.graphics.setColor(255,255,255,128)
+  local x, y = (self.pos - self.size/2):unpack()
+  love.graphics.rectangle('fill', x, y, self.size.x, self.size.y)
+  love.graphics.setColor(255,255,255,255)
 end
 
 return entity

--- a/src/gamestate/dungeon.lua
+++ b/src/gamestate/dungeon.lua
@@ -5,7 +5,7 @@ local sprites = basic.pack 'database.sprites'
 local dungeon = {}
 local camera = require 'camera' :new {}
 
-local player_entity = require 'player' :new { globals.width / 2, globals.height / 2, 1/5 }
+local player_entity = require 'player' :new { globals.width / 2, globals.height / 2, 1/2, 1/4 }
 local player_sprite = require 'sprite' :new { sprites.slime }
 
 function dungeon:init ()

--- a/src/money.lua
+++ b/src/money.lua
@@ -1,14 +1,17 @@
 
 local sprites = basic.pack 'database.sprites'
+local entity = require 'entity'
 
-local money = require 'entity' :new {
+local money = entity:new {
+  [3] = 1/8,
+  [4] = 1/4,
   ammount = 10,
   __type = 'money'
 }
 
 function money:__init ()
+  print('size:',self.size:unpack())
   self.maxhp = 1
-  self.size = 1/4
 end
 
 function money:on_collision (somebody)
@@ -23,5 +26,10 @@ function money:on_death ()
   audio:playSFX('Get')
   hump.signal.emit('entity_death', self)
 end
+
+function money:draw ()
+  entity.draw(self) -- call entity draw
+end
+
 
 return money

--- a/src/monster.lua
+++ b/src/monster.lua
@@ -29,13 +29,13 @@ function monster:on_death ()
   end)
 end
 
-function monster:on_collision (somebody)
+function monster:on_collision (somebody, h, v)
   if somebody:get_type() == 'attack' then
     self:take_damage(somebody.attack, somebody.pos)
   elseif somebody:get_type() == 'player' then
     somebody:take_damage(self.attack, self.pos)
   else
-    self:stop()
+    self:stop(h, v)
   end
 end
 
@@ -43,6 +43,10 @@ function monster:update (args)
   if self.think and type(self.think) == 'function' then self:think() end
   hump.signal.emit('entity_turn', self, self.dir)
   entity.update(self)
+end
+
+function monster:draw ()
+  entity.draw(self) -- call entity draw
 end
 
 return monster

--- a/src/physics/collision_body.lua
+++ b/src/physics/collision_body.lua
@@ -3,9 +3,8 @@
 new -> {
   [1]: x
   [2]: y
-  [3]: width/radius
+  [3]: width
   [4]: height
-  shape: 'rectangle' | 'circle'
   centred: true | false
 }
 
@@ -16,21 +15,13 @@ To specify what happens on collision, rewrite on instance the method `collision_
 
 local collision_body = basic.prototype:new {
   0, 0, 0, 0,
-  shape = 'rectangle',
   centred = false,
   __type = 'collision_body'
 }
 
 function collision_body:__init ()
   self.pos = basic.vector:new { self[1], self[2] }
-  if self.shape == 'rectangle' then
-    self.size = basic.vector:new { self[3], self[4] }
-  elseif self.shape == 'circle' then
-    self.size = self[3]
-  else
-    error("undefined shape")
-  end
-  self[1], self[2], self[3], self[4] = nil, nil, nil, nil
+  self.size = basic.vector:new { self[3], self[4] }
 end
 
 function collision_body:update ()
@@ -41,26 +32,6 @@ end
 
 function collision_body:on_collision (somebody)
   somebody:stop()
-end
-
-local function circle_rect_collision (circle, rect)
-  local colliding = false
-  local top_left = rect.centred and rect.pos - rect.size/2 or rect.pos
-  local bottom_right = rect.centred and rect.pos + rect.size/2 or rect.pos + rect.size
-  local CX, CY = circle.pos:unpack()
-  local L = top_left.x
-  local T = top_left.y
-  local R = bottom_right.x
-  local B = bottom_right.y
-  local closest = basic.vector:new{
-    math.max(math.min(CX,R),L),
-    math.max(math.min(CY,B),T),
-  }
-  local normal = closest - circle.pos
-  if normal * normal <= circle.size * circle.size then
-    colliding = true
-  end
-  return colliding
 end
 
 local function circle_circle_collision (circle1, circle2)
@@ -74,41 +45,48 @@ end
 
 local function rect_rect_collision (rect1, rect2)
   local colliding = true
-  local body_top_left = rect1.centred and rect1.pos - rect1.size/2 or rect1.pos
-  local body_bottom_right = rect1.centred and rect1.pos + rect1.size/2 or rect1.pos + rect1.size
-  local anybody_top_left = rect2.centred and rect2.pos - rect2.size/2 or rect2.pos
-  local anybody_bottom_right = rect2.centred and rect2.pos + rect2.size/2 or rect2.pos + rect2.size
 
-  if body_top_left.x > anybody_bottom_right.x then
+  if rect1.top_left.x > rect2.bottom_right.x then
     colliding = false
   end
-  if body_top_left.y > anybody_bottom_right.y then
+  if rect1.top_left.y > rect2.bottom_right.y then
     colliding = false
   end
-  if body_bottom_right.x < anybody_top_left.x then
+  if rect1.bottom_right.x < rect2.top_left.x then
     colliding = false
   end
-  if body_bottom_right.y < anybody_top_left.y then
+  if rect1.bottom_right.y < rect2.top_left.y then
     colliding = false
   end
 
   return colliding
 end
 
+local function divide_collision_axis(body1, body2)
+  local speedx, speedy = body1.speed:unpack()
+  local speedx, speedy = basic.vector:new{speedx, 0}, basic.vector:new{0, speedy}
+  local body1_x = body1.pos + speedx
+  local body1_y = body1.pos + speedy
+  local rect1_x = {
+    top_left = body1.centred and body1_x - body1.size/2 or body1_x,
+    bottom_right = body1.centred and body1_x + body1.size/2 or body1_x + body1.size,
+  }
+  local rect1_y = {
+    top_left = body1.centred and body1_y - body1.size/2 or body1_y,
+    bottom_right = body1.centred and body1_y + body1.size/2 or body1_y + body1.size,
+  }
+  local rect2 = {
+    top_left = body2.centred and body2.pos - body2.size/2 or body2.pos,
+    bottom_right = body2.centred and body2.pos + body2.size/2 or body2.pos + body2.size,
+  }
+  return rect_rect_collision(rect1_x, rect2), rect_rect_collision(rect1_y, rect2)
+end
+
 function collision_body:checkandcollide (somebody)
-  local colliding
-  if self.shape == 'rectangle' and somebody.shape == 'rectangle' then
-    colliding = rect_rect_collision(self, somebody)
-  elseif self.shape == 'rectangle' and somebody.shape == 'circle' then
-    colliding = circle_rect_collision(somebody, self)
-  elseif self.shape == 'circle' and somebody.shape == 'rectangle' then
-    colliding = circle_rect_collision(self, somebody)
-  elseif self.shape == 'circle' and somebody.shape == 'circle' then
-    colliding = circle_circle_collision(self, somebody)
-  end
-  if colliding then
-    --print('collision!', self:get_type(), somebody:get_type())
-    self:on_collision(somebody)
+  local h, v = divide_collision_axis(self, somebody)
+  if h or v then
+    print('collision!', self:get_type(), somebody:get_type())
+    self:on_collision(somebody, h, v)
   end
 end
 

--- a/src/physics/dynamic_body.lua
+++ b/src/physics/dynamic_body.lua
@@ -3,9 +3,8 @@
 new -> {
   [1]: x
   [2]: y
-  [3]: width/radius
+  [3]: width
   [4]: height
-  shape: 'rectangle' | 'circle'
   centred: true | false
 }
 
@@ -15,8 +14,8 @@ Call `update()` to update position and speed.
 ]]
 
 local dynamic_body = physics.collision_body:new {
-  [3] = 0.5,
-  shape = 'circle',
+  [3] = 1/2,
+  [4] = 1/2,
   centred = true,
   direction = {
     right      = basic.vector:new { math.cos(math.pi * 0/4), math.sin(math.pi * 0/4), },
@@ -61,9 +60,11 @@ function dynamic_body:move (acc)
   self:face(acc)
 end
 
-function dynamic_body:stop ()
+function dynamic_body:stop (h, v)
   self.pos:sub(self.speed)
-  self.speed:set()
+  if h then self.speed.x = 0 end
+  if v then self.speed.y = 0 end
+  self.pos:add(self.speed)
 end
 
 function dynamic_body:deaccelerate ()

--- a/src/player.lua
+++ b/src/player.lua
@@ -10,13 +10,13 @@ function player:__init ()
   self.locked = false
 end
 
-function player:on_collision (somebody)
+function player:on_collision (somebody, h, v)
   if somebody:get_type() == 'monster' then
     self:take_damage(somebody.attack, somebody.pos)
   elseif somebody:get_type() == 'collectable' or somebody:get_type() == 'money' then
     somebody:on_collision(self)
   elseif somebody:get_type() ~= 'attack' then
-    self:stop()
+    self:stop(h, v)
   end
 end
 

--- a/src/room.lua
+++ b/src/room.lua
@@ -92,7 +92,7 @@ end
 
 function room:check_collision (body)
   for i, tile in ipairs(self.obstacles) do
-    tile:checkandcollide(body)
+    body:checkandcollide(tile)
   end
 end
 


### PR DESCRIPTION
This huge commit implements diagonal collision sliding, but it forces the physics to use only box-shaped collisions.

The only slight bug left of collision (in my opinion) is the fact that fast speeds create bigger gaps when the collision stops the movement. For instance: when you dash-slash towards a wall, you will stop much farther from the wall had you just walked up to it.
Fixing this will require lots of refactoring, I assume. I am considering changing the game units so that the tilemap's units are in pixels. This makes collision less float-based, and could potentially help 'finding' those positions that are closest before collision, and thus fixing the high-speed-high-gap problem.

But this is low priority now.
Closes #13
